### PR TITLE
Interactive Tour For Dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "react-day-picker": "^9.11.3",
         "react-dom": "^19.2.1",
         "react-hook-form": "^7.54.2",
+        "react-joyride": "^3.0.2",
         "react-markdown": "^10.1.0",
         "recharts": "^2.15.1",
         "rehype-highlight": "^7.0.2",
@@ -766,6 +767,22 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@firebase/ai": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-1.4.0.tgz",
@@ -1388,31 +1405,31 @@
       "license": "Apache-2.0"
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
+        "@floating-ui/dom": "^1.7.6"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1420,9 +1437,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@genkit-ai/ai": {
@@ -1624,6 +1641,45 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.1.0"
+      }
+    },
+    "node_modules/@gilbarbara/types/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@google-cloud/common": {
@@ -13289,6 +13345,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -16867,10 +16929,42 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/react-joyride": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.0.2.tgz",
+      "integrity": "sha512-Tm+zXo/O8rFOUkN1yH+t38HqLvOCB8p5JTqgQD3IlLyZGCXzJEnCXtyB/BQIUC7X07kEaw0BqtKjWFzF4fyDVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19",
+        "react-dom": "16.8 - 19"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -17477,6 +17571,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/section-matter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-day-picker": "^9.11.3",
     "react-dom": "^19.2.1",
     "react-hook-form": "^7.54.2",
+    "react-joyride": "^3.0.2",
     "react-markdown": "^10.1.0",
     "recharts": "^2.15.1",
     "rehype-highlight": "^7.0.2",

--- a/src/components/dashboard/overview-client.tsx
+++ b/src/components/dashboard/overview-client.tsx
@@ -1,15 +1,29 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
     Server, FileText, Key, Activity, Terminal, Zap,
     ArrowRight, Plus, Database, Globe, GitBranch, Clock,
-    TrendingUp, ChevronRight, ExternalLink
+    TrendingUp, ChevronRight, ExternalLink, HelpCircle
 } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { ParticleDashboardHeader } from "@/components/ui/particle-dashboard-header";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+const Joyride = dynamic<any>(() => import("react-joyride").then((mod) => mod.Joyride as any), { ssr: false });
 
 interface OverviewClientProps {
     forms: any[];
@@ -18,6 +32,65 @@ interface OverviewClientProps {
 }
 
 export default function OverviewClient({ forms, connectors, systems = [] }: OverviewClientProps) {
+    const [runTour, setRunTour] = useState(false);
+    const [showIntentModal, setShowIntentModal] = useState(false);
+    const [tourKey, setTourKey] = useState(0);
+
+    useEffect(() => {
+        const hasSeenTour = localStorage.getItem("postpipe-tour-seen");
+        if (!hasSeenTour) {
+            setShowIntentModal(true);
+        }
+
+        const handleCustomReplay = () => handleReplayTour();
+        document.addEventListener('replay-tour', handleCustomReplay);
+        return () => document.removeEventListener('replay-tour', handleCustomReplay);
+    }, []);
+
+    const handleStartTour = () => {
+        setShowIntentModal(false);
+        setRunTour(true);
+        localStorage.setItem("postpipe-tour-seen", "true");
+    };
+
+    const handleSkipTour = () => {
+        setShowIntentModal(false);
+        localStorage.setItem("postpipe-tour-seen", "true");
+    };
+
+    const handleReplayTour = () => {
+        setTourKey(prev => prev + 1);
+        setRunTour(true);
+    };
+
+    const tourSteps = [
+        {
+            target: '#tour-welcome',
+            content: 'Welcome to your PostPipe Dashboard! Let us show you around.',
+            disableBeacon: true,
+        },
+        {
+            target: '#tour-connectors',
+            content: 'Connectors allow you to plug in any external database or data source securely.',
+            disableBeacon: true,
+        },
+        {
+            target: '#tour-systems',
+            content: 'Backend Systems are full-featured deployments you can generate from templates.',
+            disableBeacon: true,
+        },
+        {
+            target: '#tour-forms',
+            content: 'Static Forms let you easily collect data without writing a backend.',
+            disableBeacon: true,
+        },
+        {
+            target: '#tour-quick-actions',
+            content: 'Use Quick Actions to bootstrap new projects, connect data, or get CLI commands instantly.',
+            disableBeacon: true,
+        }
+    ];
+
     const copyCliCommand = () => {
         navigator.clipboard.writeText("npx create-postpipe-app@latest");
         toast({
@@ -42,6 +115,7 @@ export default function OverviewClient({ forms, connectors, systems = [] }: Over
             glow: "shadow-violet-500/10",
             href: "/dashboard/systems",
             trend: "+2 this week",
+            id: "tour-systems",
         },
         {
             label: "Static Forms",
@@ -54,6 +128,7 @@ export default function OverviewClient({ forms, connectors, systems = [] }: Over
             glow: "shadow-blue-500/10",
             href: "/dashboard/forms",
             trend: `${forms.filter((f: any) => f.status === "Live").length} live`,
+            id: "tour-forms",
         },
         {
             label: "Connectors",
@@ -66,6 +141,7 @@ export default function OverviewClient({ forms, connectors, systems = [] }: Over
             glow: "shadow-emerald-500/10",
             href: "/dashboard/connectors",
             trend: "All healthy",
+            id: "tour-connectors",
         },
         {
             label: "Requests",
@@ -78,6 +154,7 @@ export default function OverviewClient({ forms, connectors, systems = [] }: Over
             glow: "shadow-amber-500/10",
             href: "#",
             trend: "Coming soon",
+            id: "tour-requests",
         },
     ];
 
@@ -127,15 +204,19 @@ export default function OverviewClient({ forms, connectors, systems = [] }: Over
 
     return (
         <div className="flex flex-col gap-10">
-            <ParticleDashboardHeader
-                title="Overview"
-                subtitle="Welcome back! Here's what's happening with your infrastructure."
-            />
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                <div id="tour-welcome" className="flex-1">
+                    <ParticleDashboardHeader
+                        title="Overview"
+                        subtitle="Welcome back! Here's what's happening with your infrastructure."
+                    />
+                </div>
+            </div>
 
             {/* ── Stat Cards ── */}
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
                 {stats.map((s) => (
-                    <Link key={s.label} href={s.href} className="group">
+                    <Link key={s.label} href={s.href} className="group" id={s.id}>
                         <div className={cn(
                             "relative rounded-xl border p-5 flex flex-col gap-4",
                             "bg-card transition-all duration-200",
@@ -176,7 +257,7 @@ export default function OverviewClient({ forms, connectors, systems = [] }: Over
 
             {/* ── Quick Actions ── */}
             <div>
-                <div className="flex items-center gap-2 mb-5">
+                <div id="tour-quick-actions" className="flex items-center gap-2 mb-5 w-fit">
                     <div className="h-5 w-1 rounded-full bg-primary/50" />
                     <h2 className="text-base font-bold tracking-tight">Quick Actions</h2>
                 </div>
@@ -279,6 +360,93 @@ export default function OverviewClient({ forms, connectors, systems = [] }: Over
                     )}
                 </div>
             </div>
+
+            <Joyride
+                key={tourKey}
+                steps={tourSteps}
+                run={runTour}
+                continuous
+                showProgress
+                showSkipButton
+                disableOverlay={true}
+                locale={{ last: 'Finish' }}
+                styles={{
+                    options: {
+                        primaryColor: 'hsl(var(--primary))',
+                        textColor: 'hsl(var(--foreground))',
+                        backgroundColor: 'hsl(var(--card))',
+                        arrowColor: 'hsl(var(--card))',
+                        zIndex: 100,
+                    },
+                    tooltip: {
+                        borderRadius: '0.75rem',
+                        border: '1px solid hsl(var(--border))',
+                        boxShadow: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+                        fontFamily: 'inherit',
+                        padding: '1.25rem',
+                    },
+                    tooltipContainer: {
+                        textAlign: 'left',
+                    },
+                    tooltipContent: {
+                        padding: '0.5rem 0 1rem 0',
+                        fontSize: '0.875rem',
+                        lineHeight: '1.5',
+                    },
+                    buttonNext: {
+                        backgroundColor: 'hsl(var(--primary))',
+                        color: 'hsl(var(--primary-foreground))',
+                        borderRadius: '0.375rem',
+                        fontSize: '0.875rem',
+                        fontWeight: 500,
+                        padding: '0.5rem 1rem',
+                        outline: 'none',
+                    },
+                    buttonBack: {
+                        color: 'hsl(var(--muted-foreground))',
+                        marginRight: '0.5rem',
+                        fontSize: '0.875rem',
+                        outline: 'none',
+                    },
+                    buttonSkip: {
+                        color: 'hsl(var(--muted-foreground))',
+                        fontSize: '0.875rem',
+                        outline: 'none',
+                    },
+                    beacon: {
+                        transform: 'scale(1.5)',
+                        marginTop: '-10px',
+                    },
+                    beaconInner: {
+                        backgroundColor: 'hsl(var(--primary))',
+                    },
+                    beaconOuter: {
+                        border: '2px solid hsl(var(--primary))',
+                        backgroundColor: 'hsla(var(--primary), 0.3)',
+                    }
+                }}
+                callback={(data: any) => {
+                    const { status } = data;
+                    if (['finished', 'skipped'].includes(status)) {
+                        setRunTour(false);
+                    }
+                }}
+            />
+
+            <AlertDialog open={showIntentModal} onOpenChange={setShowIntentModal}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Welcome to PostPipe!</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Would you like a quick interactive tour to understand how to manage connectors, databases, and forms?
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel onClick={handleSkipTour}>Skip for now</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleStartTour}>Start Tour</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/src/components/ui/header-2.tsx
+++ b/src/components/ui/header-2.tsx
@@ -17,7 +17,13 @@ import {
 	SheetTitle,
 	SheetTrigger,
 } from '@/components/ui/sheet';
-import { Menu } from 'lucide-react';
+import { Menu, HelpCircle } from 'lucide-react';
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 export function Header2() {
 	const scrolled = useScroll(10);
@@ -58,12 +64,42 @@ export function Header2() {
 					))}
 					<div className="flex items-center gap-3 ml-2 border-l pl-4 border-border/50">
 						<AuthButton />
+						{pathname === '/dashboard' && (
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											variant="ghost"
+											size="icon"
+											onClick={() => document.dispatchEvent(new CustomEvent('replay-tour'))}
+											className="h-9 w-9 text-muted-foreground hover:text-foreground hover:!bg-transparent group"
+										>
+											<HelpCircle className="h-5 w-5 transition-all duration-300 group-hover:text-primary group-hover:drop-shadow-[0_0_8px_hsl(var(--primary))]" />
+											<span className="sr-only">Replay Tour</span>
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent>
+										<p>Replay Tour</p>
+									</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+						)}
 						<ThemeToggle />
 					</div>
 				</div>
 
-				{/* Mobile Menu */}
 				<div className="flex items-center gap-2 md:hidden">
+					{pathname === '/dashboard' && (
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={() => document.dispatchEvent(new CustomEvent('replay-tour'))}
+							className="h-9 w-9 shrink-0 text-muted-foreground hover:text-foreground hover:!bg-transparent group"
+							title="Replay Tour"
+						>
+							<HelpCircle className="h-5 w-5 transition-all duration-300 group-hover:text-primary group-hover:drop-shadow-[0_0_8px_hsl(var(--primary))]" />
+						</Button>
+					)}
 					<ThemeToggle />
 					<Sheet open={isOpen} onOpenChange={setIsOpen}>
 						<SheetTrigger asChild>


### PR DESCRIPTION
As part of this issue [Sub-Issue: Add Two Guided Tutorials for New Users to Understand Postpipe](https://github.com/PostPipe/Postpipe-2.0-fontend/issues/63), this feature can be introduced to provide a interactive tour for the Postpipe dashboard to the first time user login.

Following features as part of Interactive tour are built:
1. Skip/Replay for non-blocking UI experience
2. Interactive tour pop-up for first time login only